### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,14 +12,14 @@ Feather-M0	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-battery_voltage KEYWORD2
-free_ram        KEYWORD2
+battery_voltage	KEYWORD2
+free_ram	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-PIN_VBAT      LITERAL1
-PIN_RFM95_NSS LITERAL1
-PIN_RFM95_IO0 LITERAL1
-PIN_RFM95_IO1 LITERAL1
+PIN_VBAT	LITERAL1
+PIN_RFM95_NSS	LITERAL1
+PIN_RFM95_IO0	LITERAL1
+PIN_RFM95_IO1	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords